### PR TITLE
Update dependencies versions in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,13 +3,13 @@
   :url "https://github.com/clojurebridge/global-growth"
   :license {:name "Creative Commons Attribution License"
             :url "http://creativecommons.org/licenses/by/3.0/"}
-  :plugins [[lein-ring "0.8.10"]]
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-http "0.7.7"]
-                 [cheshire "5.2.0"]
-                 [ring "1.2.1"]
-                 [compojure "1.1.6"]
-                 [hiccup "1.0.4"]]
+  :plugins [[lein-ring "0.9.7"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-http "3.0.1"]
+                 [cheshire "5.6.1"]
+                 [ring "1.4.0"]
+                 [compojure "1.5.0"]
+                 [hiccup "1.0.5"]]
   :main ^:skip-aot global-growth.core
   :ring {:handler global-growth.web/handler}
   :target-path "target/%s"


### PR DESCRIPTION
If you try to run repl for this project in lighttable you get an error because of dependencies conflict. Update helps.